### PR TITLE
feat: enhance agent chat experience

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1,522 +1,522 @@
 {
-  "accent" : {
-    "description" : "Label for accent color setting.",
-    "message" : "Accent"
-  },
-  "accentColors" : {
-    "description" : "Label for accent color presets.",
-    "message" : "Accent colors"
-  },
-  "addNote" : {
-    "description" : "Label for the note button in selection toolbar.",
-    "message" : "Note"
-  },
-  "agent" : {
-    "description" : "Label/tooltip for the AI agent button.",
-    "message" : "Agent"
-  },
-  "agentContext" : {
-    "description" : "Label for the context selector",
-    "message" : "Context"
-  },
-  "agentDefaultModel" : {
-    "description" : "Default model option",
-    "message" : "Default"
-  },
-  "agentInputPlaceholder" : {
-    "description" : "Placeholder text for input field",
-    "message" : "Type your message..."
-  },
-  "agentSend" : {
-    "description" : "Text for send button",
-    "message" : "Send"
-  },
-  "agentSending" : {
-    "description" : "Text shown when message is being sent",
-    "message" : "Sending..."
-  },
-  "agentSendMessage" : {
-    "description" : "Title for send button",
-    "message" : "Send message"
-  },
-  "ai" : {
-    "description" : "Short label for the AI assistant button in selection toolbar.",
-    "message" : "AI"
-  },
-  "aiAssistant" : {
-    "description" : "Tooltip for the AI assistant button in selection toolbar.",
-    "message" : "AI Assistant"
-  },
-  "allFonts" : {
-    "description" : "Label for showing all available fonts.",
-    "message" : "All Fonts"
-  },
-  "askAI" : {
-    "description" : "Label for the AI assistant button in selection toolbar.",
-    "message" : "Ask AI"
-  },
-  "askQuestion" : {
-    "description" : "Placeholder or action label in AI panel.",
-    "message" : "Ask a question"
-  },
-  "autoScroll" : {
-    "description" : "Label for the auto-scroll button.",
-    "message" : "Auto-scroll"
-  },
-  "background" : {
-    "description" : "Label for background color setting.",
-    "message" : "Background"
-  },
-  "border" : {
-    "description" : "Label for border color setting.",
-    "message" : "Border"
-  },
-  "center" : {
-    "description" : "Center alignment option.",
-    "message" : "Center"
-  },
-  "chinese" : {
-    "description" : "Chinese language name.",
-    "message" : "Chinese"
-  },
-  "chineseFonts" : {
-    "description" : "Label for Chinese fonts section.",
-    "message" : "Chinese Fonts"
-  },
-  "clearChat" : {
-    "description" : "Label for the clear chat button in Agent UI.",
-    "message" : "Clear chat"
-  },
-  "close" : {
-    "description" : "Close button label.",
-    "message" : "Close"
-  },
-  "closeReaderMode" : {
-    "description" : "Label for button to close reader mode.",
-    "message" : "Close Reader Mode"
-  },
-  "collapseToolbar" : {
-    "description" : "Label for the collapse toolbar button",
-    "message" : "Collapse Toolbar"
-  },
-  "comingSoon" : {
-    "description" : "Label for features that will be available in the future.",
-    "message" : "Coming soon"
-  },
-  "contentWidth" : {
-    "description" : "Label for page width adjustment.",
-    "message" : "Content Width"
-  },
-  "contextArticleDesc" : {
-    "description" : "Description for article context",
-    "message" : "Use the entire article as context"
-  },
-  "contextScreenDesc" : {
-    "description" : "Description for screen context",
-    "message" : "Only use currently visible content"
-  },
-  "contextSelectionDesc" : {
-    "description" : "Description for selection context",
-    "message" : "Use selected text as context"
-  },
-  "contextTypeArticle" : {
-    "description" : "Label for article context type",
-    "message" : "Article"
-  },
-  "contextTypeScreen" : {
-    "description" : "Label for screen context type",
-    "message" : "Screen"
-  },
-  "contextTypeSelection" : {
-    "description" : "Label for selection context type",
-    "message" : "Selection"
-  },
-  "copied" : {
-    "description" : "Label shown after text has been copied.",
-    "message" : "Copied"
-  },
-  "copy" : {
-    "description" : "Label for the copy button in selection toolbar.",
-    "message" : "Copy"
-  },
-  "couldNotExtract" : {
-    "description" : "Error message when article extraction fails.",
-    "message" : "Could not extract article content"
-  },
-  "currentFont" : {
-    "description" : "Label for displaying current font.",
-    "message" : "Current Font"
-  },
-  "currentSize" : {
-    "description" : "Label for displaying current font size.",
-    "message" : "Current Size"
-  },
-  "custom" : {
-    "description" : "Custom theme option.",
-    "message" : "Custom"
-  },
-  "customTheme" : {
-    "description" : "Label for custom theme section.",
-    "message" : "Custom Theme"
-  },
-  "dark" : {
-    "description" : "Dark theme option.",
-    "message" : "Dark"
-  },
-  "darkBackgrounds" : {
-    "description" : "Label for dark background color presets.",
-    "message" : "Dark backgrounds"
-  },
-  "darkText" : {
-    "description" : "Label for dark text color presets.",
-    "message" : "Dark text"
-  },
-  "delete" : {
-    "description" : "Label for the delete button in selection toolbar.",
-    "message" : "Delete"
-  },
-  "detected" : {
-    "description" : "Label for detected language.",
-    "message" : "Detected"
-  },
-  "displaySettings" : {
-    "description" : "Title for the display settings panel.",
-    "message" : "Display Settings"
-  },
-  "download" : {
-    "description" : "Label for downloading article as Markdown.",
-    "message" : "Download"
-  },
-  "emptyStateDescription" : {
-    "description" : "Description for empty state",
-    "message" : "Select a context mode and ask any question to start the conversation."
-  },
-  "english" : {
-    "description" : "English language name.",
-    "message" : "English"
-  },
-  "englishFonts" : {
-    "description" : "Label for English fonts section.",
-    "message" : "English Fonts"
-  },
-  "errorMessage" : {
-    "description" : "Default error message",
-    "message" : "Unable to complete the request. Please try again later."
-  },
-  "errorOccurred" : {
-    "description" : "Text shown when an error occurs",
-    "message" : "An error occurred"
-  },
-  "explainSelection" : {
-    "description" : "Default query for selected text",
-    "message" : "Explain this selection"
-  },
-  "extensionDescription" : {
-    "description" : "Description of the extension.",
-    "message" : "Provide a clean, distraction-free reading experience for any article on the web."
-  },
-  "extensionName" : {
-    "description" : "Name of the extension.",
-    "message" : "ReadLite"
-  },
-  "extractingArticle" : {
-    "description" : "Message shown when extracting article content.",
-    "message" : "Extracting article..."
-  },
-  "eyecare" : {
-    "description" : "Eyecare theme option.",
-    "message" : "Eyecare"
-  },
-  "eyecareBackgrounds" : {
-    "description" : "Label for eye-care background color presets.",
-    "message" : "Eye-care backgrounds"
-  },
-  "fontArial" : {
-    "description" : "Description for Arial font.",
-    "message" : "Common sans-serif font"
-  },
-  "fontBookerly" : {
-    "description" : "Description for Bookerly font.",
-    "message" : "Kindle default reading font"
-  },
-  "fontFamily" : {
-    "description" : "Label for font selection.",
-    "message" : "Font"
-  },
-  "fontGeorgia" : {
-    "description" : "Description for Georgia font.",
-    "message" : "Classic web serif font"
-  },
-  "fontHiraginoSansGB" : {
-    "description" : "Description for Hiragino Sans GB font (English).",
-    "message" : "Clear modern sans-serif"
-  },
-  "fontMicrosoftYaHei" : {
-    "description" : "Description for Microsoft YaHei font (English).",
-    "message" : "Windows default Chinese font"
-  },
-  "fontPalatino" : {
-    "description" : "Description for Palatino font.",
-    "message" : "Classic elegant serif"
-  },
-  "fontPingFang" : {
-    "description" : "Description for PingFang font (English).",
-    "message" : "Apple default Chinese font"
-  },
-  "fontSize" : {
-    "description" : "Label for font size adjustment.",
-    "message" : "Font Size"
-  },
-  "fontSourceHanSans" : {
-    "description" : "Description for Source Han Sans font (English).",
-    "message" : "Clean modern sans-serif"
-  },
-  "fontSourceHanSerif" : {
-    "description" : "Description for Source Han Serif font (English).",
-    "message" : "Professional Chinese serif"
-  },
-  "fontTimesNewRoman" : {
-    "description" : "Description for Times New Roman font.",
-    "message" : "Traditional classic serif"
-  },
-  "highcontrast" : {
-    "description" : "High Contrast theme option.",
-    "message" : "High Contrast"
-  },
-  "highlight" : {
-    "description" : "Label for the highlight button in selection toolbar.",
-    "message" : "Highlight"
-  },
-  "justify" : {
-    "description" : "Justify alignment option.",
-    "message" : "Justify"
-  },
-  "left" : {
-    "description" : "Left alignment option.",
-    "message" : "Left"
-  },
-  "light" : {
-    "description" : "Light theme option.",
-    "message" : "Light"
-  },
-  "lightBackgrounds" : {
-    "description" : "Label for light background color presets.",
-    "message" : "Light backgrounds"
-  },
-  "lightText" : {
-    "description" : "Label for light text color presets.",
-    "message" : "Light text"
-  },
-  "lineSpacing" : {
-    "description" : "Label for line spacing adjustment.",
-    "message" : "Line Spacing"
-  },
-  "loading" : {
-    "description" : "Message shown when content is loading.",
-    "message" : "Loading..."
-  },
-  "login" : {
-    "description" : "Label for the login button.",
-    "message" : "Log in"
-  },
-  "loginButton" : {
-    "description" : "Label for the login button in the login UI.",
-    "message" : "Log In"
-  },
-  "loginMessage" : {
-    "description" : "Message explaining why login is required.",
-    "message" : "Please log in to use the AI assistant feature. Login is free and helps us prevent abuse."
-  },
-  "loginRequired" : {
-    "description" : "Title for the login required message.",
-    "message" : "Login Required"
-  },
-  "loginSafe" : {
-    "description" : "Message indicating login is safe",
-    "message" : "Safe login, no privacy concerns"
-  },
-  "minimize" : {
-    "description" : "Text for minimize/close button",
-    "message" : "Close"
-  },
-  "modelSelectorTitle" : {
-    "description" : "Title for model selector",
-    "message" : "Select AI Model"
-  },
-  "narrow" : {
-    "description" : "Narrow width option.",
-    "message" : "Narrow"
-  },
-  "noModelsAvailable" : {
-    "description" : "Text when no models are available",
-    "message" : "No models available"
-  },
-  "normal" : {
-    "description" : "Normal line spacing option.",
-    "message" : "Normal"
-  },
-  "note" : {
-    "description" : "Label for the note button in selection toolbar.",
-    "message" : "Note"
-  },
-  "paper" : {
-    "description" : "Paper theme option.",
-    "message" : "Paper"
-  },
-  "query" : {
-    "description" : "Label for the query button in selection toolbar.",
-    "message" : "Query"
-  },
-  "readingTheme" : {
-    "description" : "Label for the reading theme selection.",
-    "message" : "Theme"
-  },
-  "recommendedForBoth" : {
-    "description" : "Label for fonts recommended for both languages.",
-    "message" : "Universal"
-  },
-  "recommendedForChinese" : {
-    "description" : "Label for fonts recommended for Chinese text.",
-    "message" : "For Chinese"
-  },
-  "recommendedForEnglish" : {
-    "description" : "Label for fonts recommended for English text.",
-    "message" : "For English"
-  },
-  "refreshLanguage" : {
-    "description" : "Action/tooltip for language sync.",
-    "message" : "Sync browser language"
-  },
-  "relaxed" : {
-    "description" : "Relaxed line spacing option.",
-    "message" : "Relaxed"
-  },
-  "removeHighlight" : {
-    "description" : "Label for removing a highlight in selection toolbar.",
-    "message" : "Remove Highlight"
-  },
-  "retry" : {
-    "description" : "Text for retry button",
-    "message" : "Retry"
-  },
-  "right" : {
-    "description" : "Right alignment option.",
-    "message" : "Right"
-  },
-  "select" : {
-    "description" : "Label for color select button.",
-    "message" : "Select"
-  },
-  "selectedText" : {
-    "description" : "Label for selected text reference block",
-    "message" : "Selected Text"
-  },
-  "selectHighlightColor" : {
-    "description" : "Label for the highlight color picker dialog.",
-    "message" : "Select highlight color"
-  },
-  "selectModel" : {
-    "description" : "Label for the model selector in Agent UI.",
-    "message" : "Select Model"
-  },
-  "settings" : {
-    "description" : "Label for the settings button/panel.",
-    "message" : "Settings"
-  },
-  "share" : {
-    "description" : "Label for the share button in selection toolbar.",
-    "message" : "Share"
-  },
-  "standard" : {
-    "description" : "Standard width option.",
-    "message" : "Standard"
-  },
-  "startConversation" : {
-    "description" : "Text shown when no messages exist",
-    "message" : "Start a new conversation"
-  },
-  "summarize" : {
-    "description" : "Action label in AI panel to summarize.",
-    "message" : "Summarize article"
-  },
-  "system" : {
-    "description" : "System font option.",
-    "message" : "System"
-  },
-  "text" : {
-    "description" : "Label for text color setting.",
-    "message" : "Text"
-  },
-  "textAlignment" : {
-    "description" : "Label for text alignment options.",
-    "message" : "Text Alignment"
-  },
-  "theme" : {
-    "description" : "Label for theme button.",
-    "message" : "Theme"
-  },
-  "thinking" : {
-    "description" : "Label shown while the AI is thinking.",
-    "message" : "Thinking..."
-  },
-  "tight" : {
-    "description" : "Tight line spacing option.",
-    "message" : "Tight"
-  },
-  "tryAgain" : {
-    "description" : "Label for try again button.",
-    "message" : "Try again"
-  },
-  "ui" : {
-    "description" : "Label for UI color setting.",
-    "message" : "UI"
-  },
-  "welcomeMessage" : {
-    "description" : "Initial welcome message shown in Agent UI.",
-    "message" : "I'm here to help you understand what's currently visible on your screen. As you scroll, my context updates to focus on what you're reading now."
-  },
-  "wide" : {
-    "description" : "Wide width option.",
-    "message" : "Wide"
-  },
-  "quickSummary" : {
-    "description" : "Label for the quick summary button/feature.",
-    "message" : "Quick Summary"
-  },
-  "generatingSummary" : {
-    "description" : "Text shown when generating a summary.",
-    "message" : "Generating summary..."
-  },
-  "noSummaryAvailable" : {
-    "description" : "Text shown when no summary is available.",
-    "message" : "No summary available."
-  },
-  "translating" : {
-    "description" : "Label shown when text is being translated.",
-    "message" : "Translating"
-  },
-  "translation" : {
-    "description" : "Label shown before translated text.",
-    "message" : "Translation"
-  },
-  "translate" : {
-    "description" : "Label for the translate button in selection toolbar.",
-    "message" : "Translate"
-  },
-  "translateArticle" : {
-    "description" : "Label for the translate article button in the toolbar.",
-    "message" : "Translate Article"
-  },
-  "translatingArticle" : {
-    "description" : "Label shown when the article is being translated.",
-    "message" : "Translating Article"
-  },
-  "translationError" : {
-    "description" : "Error message shown when translation fails.",
-    "message" : "Error"
-  },
-  "translationFailed" : {
-    "description" : "Detailed error message shown when translation fails.",
-    "message" : "Translation failed. Please try again."
+  "accent": {
+    "description": "Label for accent color setting.",
+    "message": "Accent"
+  },
+  "accentColors": {
+    "description": "Label for accent color presets.",
+    "message": "Accent colors"
+  },
+  "addNote": {
+    "description": "Label for the note button in selection toolbar.",
+    "message": "Note"
+  },
+  "agent": {
+    "description": "Label/tooltip for the AI agent button.",
+    "message": "Agent"
+  },
+  "agentContext": {
+    "description": "Label for the context selector",
+    "message": "Context"
+  },
+  "agentDefaultModel": {
+    "description": "Default model option",
+    "message": "Default"
+  },
+  "agentInputPlaceholder": {
+    "description": "Placeholder text for input field",
+    "message": "Type a message, use '/' for commands"
+  },
+  "agentSend": {
+    "description": "Text for send button",
+    "message": "Send"
+  },
+  "agentSending": {
+    "description": "Text shown when message is being sent",
+    "message": "Sending..."
+  },
+  "agentSendMessage": {
+    "description": "Title for send button",
+    "message": "Send message"
+  },
+  "ai": {
+    "description": "Short label for the AI assistant button in selection toolbar.",
+    "message": "AI"
+  },
+  "aiAssistant": {
+    "description": "Tooltip for the AI assistant button in selection toolbar.",
+    "message": "AI Assistant"
+  },
+  "allFonts": {
+    "description": "Label for showing all available fonts.",
+    "message": "All Fonts"
+  },
+  "askAI": {
+    "description": "Label for the AI assistant button in selection toolbar.",
+    "message": "Ask AI"
+  },
+  "askQuestion": {
+    "description": "Placeholder or action label in AI panel.",
+    "message": "Ask a question"
+  },
+  "autoScroll": {
+    "description": "Label for the auto-scroll button.",
+    "message": "Auto-scroll"
+  },
+  "background": {
+    "description": "Label for background color setting.",
+    "message": "Background"
+  },
+  "border": {
+    "description": "Label for border color setting.",
+    "message": "Border"
+  },
+  "center": {
+    "description": "Center alignment option.",
+    "message": "Center"
+  },
+  "chinese": {
+    "description": "Chinese language name.",
+    "message": "Chinese"
+  },
+  "chineseFonts": {
+    "description": "Label for Chinese fonts section.",
+    "message": "Chinese Fonts"
+  },
+  "clearChat": {
+    "description": "Label for the clear chat button in Agent UI.",
+    "message": "Clear chat"
+  },
+  "close": {
+    "description": "Close button label.",
+    "message": "Close"
+  },
+  "closeReaderMode": {
+    "description": "Label for button to close reader mode.",
+    "message": "Close Reader Mode"
+  },
+  "collapseToolbar": {
+    "description": "Label for the collapse toolbar button",
+    "message": "Collapse Toolbar"
+  },
+  "comingSoon": {
+    "description": "Label for features that will be available in the future.",
+    "message": "Coming soon"
+  },
+  "contentWidth": {
+    "description": "Label for page width adjustment.",
+    "message": "Content Width"
+  },
+  "contextArticleDesc": {
+    "description": "Description for article context",
+    "message": "Use the entire article as context"
+  },
+  "contextScreenDesc": {
+    "description": "Description for screen context",
+    "message": "Only use currently visible content"
+  },
+  "contextSelectionDesc": {
+    "description": "Description for selection context",
+    "message": "Use selected text as context"
+  },
+  "contextTypeArticle": {
+    "description": "Label for article context type",
+    "message": "Article"
+  },
+  "contextTypeScreen": {
+    "description": "Label for screen context type",
+    "message": "Screen"
+  },
+  "contextTypeSelection": {
+    "description": "Label for selection context type",
+    "message": "Selection"
+  },
+  "copied": {
+    "description": "Label shown after text has been copied.",
+    "message": "Copied"
+  },
+  "copy": {
+    "description": "Label for the copy button in selection toolbar.",
+    "message": "Copy"
+  },
+  "couldNotExtract": {
+    "description": "Error message when article extraction fails.",
+    "message": "Could not extract article content"
+  },
+  "currentFont": {
+    "description": "Label for displaying current font.",
+    "message": "Current Font"
+  },
+  "currentSize": {
+    "description": "Label for displaying current font size.",
+    "message": "Current Size"
+  },
+  "custom": {
+    "description": "Custom theme option.",
+    "message": "Custom"
+  },
+  "customTheme": {
+    "description": "Label for custom theme section.",
+    "message": "Custom Theme"
+  },
+  "dark": {
+    "description": "Dark theme option.",
+    "message": "Dark"
+  },
+  "darkBackgrounds": {
+    "description": "Label for dark background color presets.",
+    "message": "Dark backgrounds"
+  },
+  "darkText": {
+    "description": "Label for dark text color presets.",
+    "message": "Dark text"
+  },
+  "delete": {
+    "description": "Label for the delete button in selection toolbar.",
+    "message": "Delete"
+  },
+  "detected": {
+    "description": "Label for detected language.",
+    "message": "Detected"
+  },
+  "displaySettings": {
+    "description": "Title for the display settings panel.",
+    "message": "Display Settings"
+  },
+  "download": {
+    "description": "Label for downloading article as Markdown.",
+    "message": "Download"
+  },
+  "emptyStateDescription": {
+    "description": "Description for empty state",
+    "message": "Select a context mode and ask any question to start the conversation."
+  },
+  "english": {
+    "description": "English language name.",
+    "message": "English"
+  },
+  "englishFonts": {
+    "description": "Label for English fonts section.",
+    "message": "English Fonts"
+  },
+  "errorMessage": {
+    "description": "Default error message",
+    "message": "Unable to complete the request. Please try again later."
+  },
+  "errorOccurred": {
+    "description": "Text shown when an error occurs",
+    "message": "An error occurred"
+  },
+  "explainSelection": {
+    "description": "Default query for selected text",
+    "message": "Explain this selection"
+  },
+  "extensionDescription": {
+    "description": "Description of the extension.",
+    "message": "Provide a clean, distraction-free reading experience for any article on the web."
+  },
+  "extensionName": {
+    "description": "Name of the extension.",
+    "message": "ReadLite"
+  },
+  "extractingArticle": {
+    "description": "Message shown when extracting article content.",
+    "message": "Extracting article..."
+  },
+  "eyecare": {
+    "description": "Eyecare theme option.",
+    "message": "Eyecare"
+  },
+  "eyecareBackgrounds": {
+    "description": "Label for eye-care background color presets.",
+    "message": "Eye-care backgrounds"
+  },
+  "fontArial": {
+    "description": "Description for Arial font.",
+    "message": "Common sans-serif font"
+  },
+  "fontBookerly": {
+    "description": "Description for Bookerly font.",
+    "message": "Kindle default reading font"
+  },
+  "fontFamily": {
+    "description": "Label for font selection.",
+    "message": "Font"
+  },
+  "fontGeorgia": {
+    "description": "Description for Georgia font.",
+    "message": "Classic web serif font"
+  },
+  "fontHiraginoSansGB": {
+    "description": "Description for Hiragino Sans GB font (English).",
+    "message": "Clear modern sans-serif"
+  },
+  "fontMicrosoftYaHei": {
+    "description": "Description for Microsoft YaHei font (English).",
+    "message": "Windows default Chinese font"
+  },
+  "fontPalatino": {
+    "description": "Description for Palatino font.",
+    "message": "Classic elegant serif"
+  },
+  "fontPingFang": {
+    "description": "Description for PingFang font (English).",
+    "message": "Apple default Chinese font"
+  },
+  "fontSize": {
+    "description": "Label for font size adjustment.",
+    "message": "Font Size"
+  },
+  "fontSourceHanSans": {
+    "description": "Description for Source Han Sans font (English).",
+    "message": "Clean modern sans-serif"
+  },
+  "fontSourceHanSerif": {
+    "description": "Description for Source Han Serif font (English).",
+    "message": "Professional Chinese serif"
+  },
+  "fontTimesNewRoman": {
+    "description": "Description for Times New Roman font.",
+    "message": "Traditional classic serif"
+  },
+  "highcontrast": {
+    "description": "High Contrast theme option.",
+    "message": "High Contrast"
+  },
+  "highlight": {
+    "description": "Label for the highlight button in selection toolbar.",
+    "message": "Highlight"
+  },
+  "justify": {
+    "description": "Justify alignment option.",
+    "message": "Justify"
+  },
+  "left": {
+    "description": "Left alignment option.",
+    "message": "Left"
+  },
+  "light": {
+    "description": "Light theme option.",
+    "message": "Light"
+  },
+  "lightBackgrounds": {
+    "description": "Label for light background color presets.",
+    "message": "Light backgrounds"
+  },
+  "lightText": {
+    "description": "Label for light text color presets.",
+    "message": "Light text"
+  },
+  "lineSpacing": {
+    "description": "Label for line spacing adjustment.",
+    "message": "Line Spacing"
+  },
+  "loading": {
+    "description": "Message shown when content is loading.",
+    "message": "Loading..."
+  },
+  "login": {
+    "description": "Label for the login button.",
+    "message": "Log in"
+  },
+  "loginButton": {
+    "description": "Label for the login button in the login UI.",
+    "message": "Log In"
+  },
+  "loginMessage": {
+    "description": "Message explaining why login is required.",
+    "message": "Please log in to use the AI assistant feature. Login is free and helps us prevent abuse."
+  },
+  "loginRequired": {
+    "description": "Title for the login required message.",
+    "message": "Login Required"
+  },
+  "loginSafe": {
+    "description": "Message indicating login is safe",
+    "message": "Safe login, no privacy concerns"
+  },
+  "minimize": {
+    "description": "Text for minimize/close button",
+    "message": "Close"
+  },
+  "modelSelectorTitle": {
+    "description": "Title for model selector",
+    "message": "Select AI Model"
+  },
+  "narrow": {
+    "description": "Narrow width option.",
+    "message": "Narrow"
+  },
+  "noModelsAvailable": {
+    "description": "Text when no models are available",
+    "message": "No models available"
+  },
+  "normal": {
+    "description": "Normal line spacing option.",
+    "message": "Normal"
+  },
+  "note": {
+    "description": "Label for the note button in selection toolbar.",
+    "message": "Note"
+  },
+  "paper": {
+    "description": "Paper theme option.",
+    "message": "Paper"
+  },
+  "query": {
+    "description": "Label for the query button in selection toolbar.",
+    "message": "Query"
+  },
+  "readingTheme": {
+    "description": "Label for the reading theme selection.",
+    "message": "Theme"
+  },
+  "recommendedForBoth": {
+    "description": "Label for fonts recommended for both languages.",
+    "message": "Universal"
+  },
+  "recommendedForChinese": {
+    "description": "Label for fonts recommended for Chinese text.",
+    "message": "For Chinese"
+  },
+  "recommendedForEnglish": {
+    "description": "Label for fonts recommended for English text.",
+    "message": "For English"
+  },
+  "refreshLanguage": {
+    "description": "Action/tooltip for language sync.",
+    "message": "Sync browser language"
+  },
+  "relaxed": {
+    "description": "Relaxed line spacing option.",
+    "message": "Relaxed"
+  },
+  "removeHighlight": {
+    "description": "Label for removing a highlight in selection toolbar.",
+    "message": "Remove Highlight"
+  },
+  "retry": {
+    "description": "Text for retry button",
+    "message": "Retry"
+  },
+  "right": {
+    "description": "Right alignment option.",
+    "message": "Right"
+  },
+  "select": {
+    "description": "Label for color select button.",
+    "message": "Select"
+  },
+  "selectedText": {
+    "description": "Label for selected text reference block",
+    "message": "Selected Text"
+  },
+  "selectHighlightColor": {
+    "description": "Label for the highlight color picker dialog.",
+    "message": "Select highlight color"
+  },
+  "selectModel": {
+    "description": "Label for the model selector in Agent UI.",
+    "message": "Select Model"
+  },
+  "settings": {
+    "description": "Label for the settings button/panel.",
+    "message": "Settings"
+  },
+  "share": {
+    "description": "Label for the share button in selection toolbar.",
+    "message": "Share"
+  },
+  "standard": {
+    "description": "Standard width option.",
+    "message": "Standard"
+  },
+  "startConversation": {
+    "description": "Text shown when no messages exist",
+    "message": "Start a new conversation"
+  },
+  "summarize": {
+    "description": "Action label in AI panel to summarize.",
+    "message": "Summarize article"
+  },
+  "system": {
+    "description": "System font option.",
+    "message": "System"
+  },
+  "text": {
+    "description": "Label for text color setting.",
+    "message": "Text"
+  },
+  "textAlignment": {
+    "description": "Label for text alignment options.",
+    "message": "Text Alignment"
+  },
+  "theme": {
+    "description": "Label for theme button.",
+    "message": "Theme"
+  },
+  "thinking": {
+    "description": "Label shown while the AI is thinking.",
+    "message": "Thinking..."
+  },
+  "tight": {
+    "description": "Tight line spacing option.",
+    "message": "Tight"
+  },
+  "tryAgain": {
+    "description": "Label for try again button.",
+    "message": "Try again"
+  },
+  "ui": {
+    "description": "Label for UI color setting.",
+    "message": "UI"
+  },
+  "welcomeMessage": {
+    "description": "Initial welcome message shown in Agent UI.",
+    "message": "I'm here to help you understand what's currently visible on your screen. As you scroll, my context updates to focus on what you're reading now."
+  },
+  "wide": {
+    "description": "Wide width option.",
+    "message": "Wide"
+  },
+  "quickSummary": {
+    "description": "Label for the quick summary button/feature.",
+    "message": "Quick Summary"
+  },
+  "generatingSummary": {
+    "description": "Text shown when generating a summary.",
+    "message": "Generating summary..."
+  },
+  "noSummaryAvailable": {
+    "description": "Text shown when no summary is available.",
+    "message": "No summary available."
+  },
+  "translating": {
+    "description": "Label shown when text is being translated.",
+    "message": "Translating"
+  },
+  "translation": {
+    "description": "Label shown before translated text.",
+    "message": "Translation"
+  },
+  "translate": {
+    "description": "Label for the translate button in selection toolbar.",
+    "message": "Translate"
+  },
+  "translateArticle": {
+    "description": "Label for the translate article button in the toolbar.",
+    "message": "Translate Article"
+  },
+  "translatingArticle": {
+    "description": "Label shown when the article is being translated.",
+    "message": "Translating Article"
+  },
+  "translationError": {
+    "description": "Error message shown when translation fails.",
+    "message": "Error"
+  },
+  "translationFailed": {
+    "description": "Detailed error message shown when translation fails.",
+    "message": "Translation failed. Please try again."
   }
 }

--- a/locales/zh/messages.json
+++ b/locales/zh/messages.json
@@ -1,522 +1,522 @@
 {
-  "accent" : {
-    "description" : "Label for accent color setting.",
-    "message" : "强调"
-  },
-  "accentColors" : {
-    "description" : "Label for accent color presets.",
-    "message" : "强调色"
-  },
-  "addNote" : {
-    "description" : "Label for the note button in selection toolbar.",
-    "message" : "写想法"
-  },
-  "agent" : {
-    "description" : "AI 助手按钮的标签/提示",
-    "message" : "Agent"
-  },
-  "agentContext" : {
-    "description" : "上下文选择器的标签",
-    "message" : "上下文"
-  },
-  "agentDefaultModel" : {
-    "description" : "默认模型选项",
-    "message" : "默认"
-  },
-  "agentInputPlaceholder" : {
-    "description" : "输入框的占位文本",
-    "message" : "输入您的消息..."
-  },
-  "agentSend" : {
-    "description" : "发送按钮的文本",
-    "message" : "发送"
-  },
-  "agentSending" : {
-    "description" : "消息发送中显示的文本",
-    "message" : "发送中..."
-  },
-  "agentSendMessage" : {
-    "description" : "发送按钮的标题",
-    "message" : "发送消息"
-  },
-  "ai" : {
-    "description" : "Short label for the AI assistant button in selection toolbar.",
-    "message" : "AI"
-  },
-  "aiAssistant" : {
-    "description" : "Tooltip for the AI assistant button in selection toolbar.",
-    "message" : "AI 助手"
-  },
-  "allFonts" : {
-    "description" : "Label for showing all available fonts.",
-    "message" : "所有字体"
-  },
-  "askAI" : {
-    "description" : "Label for the AI assistant button in selection toolbar.",
-    "message" : "问 AI"
-  },
-  "askQuestion" : {
-    "description" : "AI 面板中的占位符或操作标签",
-    "message" : "请输入问题"
-  },
-  "autoScroll" : {
-    "description" : "自动滚动按钮的标签",
-    "message" : "自动滚动"
-  },
-  "background" : {
-    "description" : "Label for background color setting.",
-    "message" : "背景"
-  },
-  "border" : {
-    "description" : "Label for border color setting.",
-    "message" : "边框"
-  },
-  "center" : {
-    "description" : "Center alignment option.",
-    "message" : "居中"
-  },
-  "chinese" : {
-    "description" : "Chinese language name.",
-    "message" : "中文"
-  },
-  "chineseFonts" : {
-    "description" : "Label for Chinese fonts section.",
-    "message" : "中文字体"
-  },
-  "clearChat" : {
-    "description" : "Agent UI 中清除对话按钮的标签",
-    "message" : "清除对话"
-  },
-  "close" : {
-    "description" : "Close button label.",
-    "message" : "关闭"
-  },
-  "closeReaderMode" : {
-    "description" : "Label for button to close reader mode.",
-    "message" : "关闭阅读模式"
-  },
-  "collapseToolbar" : {
-    "description" : "折叠工具栏按钮的标签",
-    "message" : "折叠工具栏"
-  },
-  "comingSoon" : {
-    "description" : "未来将提供的功能的标签",
-    "message" : "即将推出"
-  },
-  "contentWidth" : {
-    "description" : "Label for page width adjustment.",
-    "message" : "页面宽度"
-  },
-  "contextArticleDesc" : {
-    "description" : "文章上下文的描述",
-    "message" : "使用整篇文章作为上下文"
-  },
-  "contextScreenDesc" : {
-    "description" : "屏幕上下文的描述",
-    "message" : "仅使用当前可见内容"
-  },
-  "contextSelectionDesc" : {
-    "description" : "Description for selection context",
-    "message" : "使用选中文本作为上下文"
-  },
-  "contextTypeArticle" : {
-    "description" : "Agent UI 中文章上下文类型的标签",
-    "message" : "文章"
-  },
-  "contextTypeScreen" : {
-    "description" : "Agent UI 中屏幕上下文类型的标签",
-    "message" : "屏幕"
-  },
-  "contextTypeSelection" : {
-    "description" : "Agent UI 中选择上下文类型的标签",
-    "message" : "选择"
-  },
-  "copied" : {
-    "description" : "Label shown after text has been copied.",
-    "message" : "已复制"
-  },
-  "copy" : {
-    "description" : "Label for the copy button in selection toolbar.",
-    "message" : "复制"
-  },
-  "couldNotExtract" : {
-    "description" : "Error message when article extraction fails.",
-    "message" : "无法提取文章内容"
-  },
-  "currentFont" : {
-    "description" : "Label for displaying current font.",
-    "message" : "当前字体"
-  },
-  "currentSize" : {
-    "description" : "显示当前字体大小标签",
-    "message" : "当前字号"
-  },
-  "custom" : {
-    "description" : "Custom theme option.",
-    "message" : "自定义"
-  },
-  "customTheme" : {
-    "description" : "Label for custom theme section.",
-    "message" : "自定义主题"
-  },
-  "dark" : {
-    "description" : "Dark theme option.",
-    "message" : "暗黑"
-  },
-  "darkBackgrounds" : {
-    "description" : "Label for dark background color presets.",
-    "message" : "深色背景"
-  },
-  "darkText" : {
-    "description" : "Label for dark text color presets.",
-    "message" : "深色文本"
-  },
-  "delete" : {
-    "description" : "Label for the delete button in selection toolbar.",
-    "message" : "删除"
-  },
-  "detected" : {
-    "description" : "Label for detected language.",
-    "message" : "已检测"
-  },
-  "displaySettings" : {
-    "description" : "Title for the display settings panel.",
-    "message" : "显示设置"
-  },
-  "download" : {
-    "description" : "下载文章为 Markdown 格式标签",
-    "message" : "下载"
-  },
-  "emptyStateDescription" : {
-    "description" : "空状态的描述",
-    "message" : "选择上下文模式并提问以开始对话"
-  },
-  "english" : {
-    "description" : "English language name.",
-    "message" : "英文"
-  },
-  "englishFonts" : {
-    "description" : "Label for English fonts section.",
-    "message" : "英文字体"
-  },
-  "errorMessage" : {
-    "description" : "默认错误消息",
-    "message" : "无法完成请求，请稍后再试"
-  },
-  "errorOccurred" : {
-    "description" : "发生错误时显示的文本",
-    "message" : "发生错误"
-  },
-  "explainSelection" : {
-    "description" : "Default query for selected text",
-    "message" : "解释这段选中内容"
-  },
-  "extensionDescription" : {
-    "description" : "Description of the extension.",
-    "message" : "为任何网页文章提供清晰无干扰的阅读体验。"
-  },
-  "extensionName" : {
-    "description" : "Name of the extension.",
-    "message" : "读点东西"
-  },
-  "extractingArticle" : {
-    "description" : "Message shown when extracting article content.",
-    "message" : "提取文章中..."
-  },
-  "eyecare" : {
-    "description" : "Eyecare theme option.",
-    "message" : "护眼"
-  },
-  "eyecareBackgrounds" : {
-    "description" : "Label for eye-care background color presets.",
-    "message" : "护眼背景"
-  },
-  "fontArial" : {
-    "description" : "Arial 字体的描述",
-    "message" : "通用无衬线字体"
-  },
-  "fontBookerly" : {
-    "description" : "Bookerly 字体的描述",
-    "message" : "Kindle默认阅读字体"
-  },
-  "fontFamily" : {
-    "description" : "Label for font selection.",
-    "message" : "字体"
-  },
-  "fontGeorgia" : {
-    "description" : "Georgia 字体的描述",
-    "message" : "经典网页衬线字体"
-  },
-  "fontHiraginoSansGB" : {
-    "description" : "冬青黑体字体的描述（中文）",
-    "message" : "清晰的现代无衬线字体"
-  },
-  "fontMicrosoftYaHei" : {
-    "description" : "微软雅黑字体的描述（中文）",
-    "message" : "Windows系统默认中文字体"
-  },
-  "fontPalatino" : {
-    "description" : "Palatino 字体的描述",
-    "message" : "经典优雅的衬线字体"
-  },
-  "fontPingFang" : {
-    "description" : "苹方字体的描述（中文）",
-    "message" : "苹果设备默认中文字体"
-  },
-  "fontSize" : {
-    "description" : "Label for font size adjustment.",
-    "message" : "字号"
-  },
-  "fontSourceHanSans" : {
-    "description" : "思源黑体字体的描述（中文）",
-    "message" : "现代清晰的无衬线字体"
-  },
-  "fontSourceHanSerif" : {
-    "description" : "思源宋体字体的描述（中文）",
-    "message" : "专业中文衬线字体"
-  },
-  "fontTimesNewRoman" : {
-    "description" : "Times New Roman 字体的描述",
-    "message" : "传统经典衬线字体"
-  },
-  "highcontrast" : {
-    "description" : "High Contrast theme option.",
-    "message" : "高对比度"
-  },
-  "highlight" : {
-    "description" : "Label for the highlight button in selection toolbar.",
-    "message" : "划线"
-  },
-  "justify" : {
-    "description" : "Justify alignment option.",
-    "message" : "两端对齐"
-  },
-  "left" : {
-    "description" : "Left alignment option.",
-    "message" : "左对齐"
-  },
-  "light" : {
-    "description" : "Light theme option.",
-    "message" : "明亮"
-  },
-  "lightBackgrounds" : {
-    "description" : "Label for light background color presets.",
-    "message" : "浅色背景"
-  },
-  "lightText" : {
-    "description" : "Label for light text color presets.",
-    "message" : "浅色文本"
-  },
-  "lineSpacing" : {
-    "description" : "Label for line spacing adjustment.",
-    "message" : "行间距"
-  },
-  "loading" : {
-    "description" : "内容加载时显示的消息",
-    "message" : "加载中..."
-  },
-  "login" : {
-    "description" : "登录按钮的标签",
-    "message" : "登录"
-  },
-  "loginButton" : {
-    "description" : "登录界面中登录按钮的标签",
-    "message" : "登录"
-  },
-  "loginMessage" : {
-    "description" : "解释为什么需要登录的消息",
-    "message" : "请登录以使用AI助手功能。登录是免费的，有助于我们防止滥用。"
-  },
-  "loginRequired" : {
-    "description" : "登录提示标题",
-    "message" : "需要登录"
-  },
-  "loginSafe" : {
-    "description" : "表示登录安全的消息",
-    "message" : "安全登录，无需担心隐私"
-  },
-  "minimize" : {
-    "description" : "最小化/关闭按钮的文本",
-    "message" : "关闭"
-  },
-  "modelSelectorTitle" : {
-    "description" : "模型选择器的标题",
-    "message" : "选择AI模型"
-  },
-  "narrow" : {
-    "description" : "Narrow width option.",
-    "message" : "窄"
-  },
-  "noModelsAvailable" : {
-    "description" : "无可用模型时的文本",
-    "message" : "无可用模型"
-  },
-  "normal" : {
-    "description" : "Normal line spacing option.",
-    "message" : "标准"
-  },
-  "note" : {
-    "description" : "Label for the note button in selection toolbar.",
-    "message" : "想法"
-  },
-  "paper" : {
-    "description" : "Paper theme option.",
-    "message" : "纸张"
-  },
-  "query" : {
-    "description" : "Label for the query button in selection toolbar.",
-    "message" : "查询"
-  },
-  "readingTheme" : {
-    "description" : "Label for the reading theme selection.",
-    "message" : "阅读主题"
-  },
-  "recommendedForBoth" : {
-    "description" : "Label for fonts recommended for both languages.",
-    "message" : "通用字体"
-  },
-  "recommendedForChinese" : {
-    "description" : "Label for fonts recommended for Chinese text.",
-    "message" : "推荐中文"
-  },
-  "recommendedForEnglish" : {
-    "description" : "Label for fonts recommended for English text.",
-    "message" : "推荐英文"
-  },
-  "refreshLanguage" : {
-    "description" : "语言同步的操作/提示",
-    "message" : "同步浏览器语言"
-  },
-  "relaxed" : {
-    "description" : "宽松行间距选项",
-    "message" : "宽松"
-  },
-  "removeHighlight" : {
-    "description" : "Label for removing a highlight in selection toolbar.",
-    "message" : "删除划线"
-  },
-  "retry" : {
-    "description" : "重试按钮的文本",
-    "message" : "重试"
-  },
-  "right" : {
-    "description" : "Right alignment option.",
-    "message" : "右对齐"
-  },
-  "select" : {
-    "description" : "Label for color select button.",
-    "message" : "选择"
-  },
-  "selectedText" : {
-    "description" : "Label for selected text reference block",
-    "message" : "选中文本"
-  },
-  "selectHighlightColor" : {
-    "description" : "Label for the highlight color picker dialog.",
-    "message" : "选择划线颜色"
-  },
-  "selectModel" : {
-    "description" : "Agent UI 中模型选择器的标签",
-    "message" : "选择模型"
-  },
-  "settings" : {
-    "description" : "设置按钮/面板的标签",
-    "message" : "设置"
-  },
-  "share" : {
-    "description" : "Label for the share button in selection toolbar.",
-    "message" : "分享"
-  },
-  "standard" : {
-    "description" : "Standard width option.",
-    "message" : "标准"
-  },
-  "startConversation" : {
-    "description" : "无消息时显示的文本",
-    "message" : "开始新对话"
-  },
-  "summarize" : {
-    "description" : "AI 面板中总结文章的操作标签",
-    "message" : "总结文章"
-  },
-  "system" : {
-    "description" : "系统字体选项",
-    "message" : "系统"
-  },
-  "text" : {
-    "description" : "Label for text color setting.",
-    "message" : "文本"
-  },
-  "textAlignment" : {
-    "description" : "Label for text alignment options.",
-    "message" : "文本对齐"
-  },
-  "theme" : {
-    "description" : "Label for theme button.",
-    "message" : "主题"
-  },
-  "thinking" : {
-    "description" : "AI 思考时显示的标签",
-    "message" : "思考中..."
-  },
-  "tight" : {
-    "description" : "Tight line spacing option.",
-    "message" : "紧凑"
-  },
-  "tryAgain" : {
-    "description" : "Label for try again button.",
-    "message" : "重试"
-  },
-  "ui" : {
-    "description" : "UI 颜色设置的标签",
-    "message" : "UI"
-  },
-  "welcomeMessage" : {
-    "description" : "Agent UI 中显示的初始欢迎消息",
-    "message" : "我可以帮助你理解当前屏幕上显示的内容。当你滚动页面时，我的上下文会更新以关注你正在阅读的内容。"
-  },
-  "wide" : {
-    "description" : "Wide width option.",
-    "message" : "宽"
-  },
-  "quickSummary" : {
-    "description" : "Label for the quick summary button/feature.",
-    "message" : "快速摘要"
-  },
-  "generatingSummary" : {
-    "description" : "Text shown when generating a summary.",
-    "message" : "正在生成摘要..."
-  },
-  "noSummaryAvailable" : {
-    "description" : "Text shown when no summary is available.",
-    "message" : "暂无可用摘要。"
-  },
-  "translating" : {
-    "description" : "Label shown when text is being translated.",
-    "message" : "翻译中"
-  },
-  "translation" : {
-    "description" : "Label shown before translated text.",
-    "message" : "翻译"
-  },
-  "translate" : {
-    "description" : "Label for the translate button in selection toolbar.",
-    "message" : "翻译"
-  },
-  "translateArticle" : {
-    "description" : "Label for the translate article button in the toolbar.",
-    "message" : "翻译全文"
-  },
-  "translatingArticle" : {
-    "description" : "Label shown when the article is being translated.",
-    "message" : "正在翻译全文"
-  },
-  "translationError" : {
-    "description" : "Error message shown when translation fails.",
-    "message" : "错误"
-  },
-  "translationFailed" : {
-    "description" : "Detailed error message shown when translation fails.",
-    "message" : "翻译失败，请重试"
+  "accent": {
+    "description": "Label for accent color setting.",
+    "message": "强调"
+  },
+  "accentColors": {
+    "description": "Label for accent color presets.",
+    "message": "强调色"
+  },
+  "addNote": {
+    "description": "Label for the note button in selection toolbar.",
+    "message": "写想法"
+  },
+  "agent": {
+    "description": "AI 助手按钮的标签/提示",
+    "message": "Agent"
+  },
+  "agentContext": {
+    "description": "上下文选择器的标签",
+    "message": "上下文"
+  },
+  "agentDefaultModel": {
+    "description": "默认模型选项",
+    "message": "默认"
+  },
+  "agentInputPlaceholder": {
+    "description": "输入框的占位文本",
+    "message": "输入消息，使用 '/' 快捷指令"
+  },
+  "agentSend": {
+    "description": "发送按钮的文本",
+    "message": "发送"
+  },
+  "agentSending": {
+    "description": "消息发送中显示的文本",
+    "message": "发送中..."
+  },
+  "agentSendMessage": {
+    "description": "发送按钮的标题",
+    "message": "发送消息"
+  },
+  "ai": {
+    "description": "Short label for the AI assistant button in selection toolbar.",
+    "message": "AI"
+  },
+  "aiAssistant": {
+    "description": "Tooltip for the AI assistant button in selection toolbar.",
+    "message": "AI 助手"
+  },
+  "allFonts": {
+    "description": "Label for showing all available fonts.",
+    "message": "所有字体"
+  },
+  "askAI": {
+    "description": "Label for the AI assistant button in selection toolbar.",
+    "message": "问 AI"
+  },
+  "askQuestion": {
+    "description": "AI 面板中的占位符或操作标签",
+    "message": "请输入问题"
+  },
+  "autoScroll": {
+    "description": "自动滚动按钮的标签",
+    "message": "自动滚动"
+  },
+  "background": {
+    "description": "Label for background color setting.",
+    "message": "背景"
+  },
+  "border": {
+    "description": "Label for border color setting.",
+    "message": "边框"
+  },
+  "center": {
+    "description": "Center alignment option.",
+    "message": "居中"
+  },
+  "chinese": {
+    "description": "Chinese language name.",
+    "message": "中文"
+  },
+  "chineseFonts": {
+    "description": "Label for Chinese fonts section.",
+    "message": "中文字体"
+  },
+  "clearChat": {
+    "description": "Agent UI 中清除对话按钮的标签",
+    "message": "清除对话"
+  },
+  "close": {
+    "description": "Close button label.",
+    "message": "关闭"
+  },
+  "closeReaderMode": {
+    "description": "Label for button to close reader mode.",
+    "message": "关闭阅读模式"
+  },
+  "collapseToolbar": {
+    "description": "折叠工具栏按钮的标签",
+    "message": "折叠工具栏"
+  },
+  "comingSoon": {
+    "description": "未来将提供的功能的标签",
+    "message": "即将推出"
+  },
+  "contentWidth": {
+    "description": "Label for page width adjustment.",
+    "message": "页面宽度"
+  },
+  "contextArticleDesc": {
+    "description": "文章上下文的描述",
+    "message": "使用整篇文章作为上下文"
+  },
+  "contextScreenDesc": {
+    "description": "屏幕上下文的描述",
+    "message": "仅使用当前可见内容"
+  },
+  "contextSelectionDesc": {
+    "description": "Description for selection context",
+    "message": "使用选中文本作为上下文"
+  },
+  "contextTypeArticle": {
+    "description": "Agent UI 中文章上下文类型的标签",
+    "message": "文章"
+  },
+  "contextTypeScreen": {
+    "description": "Agent UI 中屏幕上下文类型的标签",
+    "message": "屏幕"
+  },
+  "contextTypeSelection": {
+    "description": "Agent UI 中选择上下文类型的标签",
+    "message": "选择"
+  },
+  "copied": {
+    "description": "Label shown after text has been copied.",
+    "message": "已复制"
+  },
+  "copy": {
+    "description": "Label for the copy button in selection toolbar.",
+    "message": "复制"
+  },
+  "couldNotExtract": {
+    "description": "Error message when article extraction fails.",
+    "message": "无法提取文章内容"
+  },
+  "currentFont": {
+    "description": "Label for displaying current font.",
+    "message": "当前字体"
+  },
+  "currentSize": {
+    "description": "显示当前字体大小标签",
+    "message": "当前字号"
+  },
+  "custom": {
+    "description": "Custom theme option.",
+    "message": "自定义"
+  },
+  "customTheme": {
+    "description": "Label for custom theme section.",
+    "message": "自定义主题"
+  },
+  "dark": {
+    "description": "Dark theme option.",
+    "message": "暗黑"
+  },
+  "darkBackgrounds": {
+    "description": "Label for dark background color presets.",
+    "message": "深色背景"
+  },
+  "darkText": {
+    "description": "Label for dark text color presets.",
+    "message": "深色文本"
+  },
+  "delete": {
+    "description": "Label for the delete button in selection toolbar.",
+    "message": "删除"
+  },
+  "detected": {
+    "description": "Label for detected language.",
+    "message": "已检测"
+  },
+  "displaySettings": {
+    "description": "Title for the display settings panel.",
+    "message": "显示设置"
+  },
+  "download": {
+    "description": "下载文章为 Markdown 格式标签",
+    "message": "下载"
+  },
+  "emptyStateDescription": {
+    "description": "空状态的描述",
+    "message": "选择上下文模式并提问以开始对话"
+  },
+  "english": {
+    "description": "English language name.",
+    "message": "英文"
+  },
+  "englishFonts": {
+    "description": "Label for English fonts section.",
+    "message": "英文字体"
+  },
+  "errorMessage": {
+    "description": "默认错误消息",
+    "message": "无法完成请求，请稍后再试"
+  },
+  "errorOccurred": {
+    "description": "发生错误时显示的文本",
+    "message": "发生错误"
+  },
+  "explainSelection": {
+    "description": "Default query for selected text",
+    "message": "解释这段选中内容"
+  },
+  "extensionDescription": {
+    "description": "Description of the extension.",
+    "message": "为任何网页文章提供清晰无干扰的阅读体验。"
+  },
+  "extensionName": {
+    "description": "Name of the extension.",
+    "message": "读点东西"
+  },
+  "extractingArticle": {
+    "description": "Message shown when extracting article content.",
+    "message": "提取文章中..."
+  },
+  "eyecare": {
+    "description": "Eyecare theme option.",
+    "message": "护眼"
+  },
+  "eyecareBackgrounds": {
+    "description": "Label for eye-care background color presets.",
+    "message": "护眼背景"
+  },
+  "fontArial": {
+    "description": "Arial 字体的描述",
+    "message": "通用无衬线字体"
+  },
+  "fontBookerly": {
+    "description": "Bookerly 字体的描述",
+    "message": "Kindle默认阅读字体"
+  },
+  "fontFamily": {
+    "description": "Label for font selection.",
+    "message": "字体"
+  },
+  "fontGeorgia": {
+    "description": "Georgia 字体的描述",
+    "message": "经典网页衬线字体"
+  },
+  "fontHiraginoSansGB": {
+    "description": "冬青黑体字体的描述（中文）",
+    "message": "清晰的现代无衬线字体"
+  },
+  "fontMicrosoftYaHei": {
+    "description": "微软雅黑字体的描述（中文）",
+    "message": "Windows系统默认中文字体"
+  },
+  "fontPalatino": {
+    "description": "Palatino 字体的描述",
+    "message": "经典优雅的衬线字体"
+  },
+  "fontPingFang": {
+    "description": "苹方字体的描述（中文）",
+    "message": "苹果设备默认中文字体"
+  },
+  "fontSize": {
+    "description": "Label for font size adjustment.",
+    "message": "字号"
+  },
+  "fontSourceHanSans": {
+    "description": "思源黑体字体的描述（中文）",
+    "message": "现代清晰的无衬线字体"
+  },
+  "fontSourceHanSerif": {
+    "description": "思源宋体字体的描述（中文）",
+    "message": "专业中文衬线字体"
+  },
+  "fontTimesNewRoman": {
+    "description": "Times New Roman 字体的描述",
+    "message": "传统经典衬线字体"
+  },
+  "highcontrast": {
+    "description": "High Contrast theme option.",
+    "message": "高对比度"
+  },
+  "highlight": {
+    "description": "Label for the highlight button in selection toolbar.",
+    "message": "划线"
+  },
+  "justify": {
+    "description": "Justify alignment option.",
+    "message": "两端对齐"
+  },
+  "left": {
+    "description": "Left alignment option.",
+    "message": "左对齐"
+  },
+  "light": {
+    "description": "Light theme option.",
+    "message": "明亮"
+  },
+  "lightBackgrounds": {
+    "description": "Label for light background color presets.",
+    "message": "浅色背景"
+  },
+  "lightText": {
+    "description": "Label for light text color presets.",
+    "message": "浅色文本"
+  },
+  "lineSpacing": {
+    "description": "Label for line spacing adjustment.",
+    "message": "行间距"
+  },
+  "loading": {
+    "description": "内容加载时显示的消息",
+    "message": "加载中..."
+  },
+  "login": {
+    "description": "登录按钮的标签",
+    "message": "登录"
+  },
+  "loginButton": {
+    "description": "登录界面中登录按钮的标签",
+    "message": "登录"
+  },
+  "loginMessage": {
+    "description": "解释为什么需要登录的消息",
+    "message": "请登录以使用AI助手功能。登录是免费的，有助于我们防止滥用。"
+  },
+  "loginRequired": {
+    "description": "登录提示标题",
+    "message": "需要登录"
+  },
+  "loginSafe": {
+    "description": "表示登录安全的消息",
+    "message": "安全登录，无需担心隐私"
+  },
+  "minimize": {
+    "description": "最小化/关闭按钮的文本",
+    "message": "关闭"
+  },
+  "modelSelectorTitle": {
+    "description": "模型选择器的标题",
+    "message": "选择AI模型"
+  },
+  "narrow": {
+    "description": "Narrow width option.",
+    "message": "窄"
+  },
+  "noModelsAvailable": {
+    "description": "无可用模型时的文本",
+    "message": "无可用模型"
+  },
+  "normal": {
+    "description": "Normal line spacing option.",
+    "message": "标准"
+  },
+  "note": {
+    "description": "Label for the note button in selection toolbar.",
+    "message": "想法"
+  },
+  "paper": {
+    "description": "Paper theme option.",
+    "message": "纸张"
+  },
+  "query": {
+    "description": "Label for the query button in selection toolbar.",
+    "message": "查询"
+  },
+  "readingTheme": {
+    "description": "Label for the reading theme selection.",
+    "message": "阅读主题"
+  },
+  "recommendedForBoth": {
+    "description": "Label for fonts recommended for both languages.",
+    "message": "通用字体"
+  },
+  "recommendedForChinese": {
+    "description": "Label for fonts recommended for Chinese text.",
+    "message": "推荐中文"
+  },
+  "recommendedForEnglish": {
+    "description": "Label for fonts recommended for English text.",
+    "message": "推荐英文"
+  },
+  "refreshLanguage": {
+    "description": "语言同步的操作/提示",
+    "message": "同步浏览器语言"
+  },
+  "relaxed": {
+    "description": "宽松行间距选项",
+    "message": "宽松"
+  },
+  "removeHighlight": {
+    "description": "Label for removing a highlight in selection toolbar.",
+    "message": "删除划线"
+  },
+  "retry": {
+    "description": "重试按钮的文本",
+    "message": "重试"
+  },
+  "right": {
+    "description": "Right alignment option.",
+    "message": "右对齐"
+  },
+  "select": {
+    "description": "Label for color select button.",
+    "message": "选择"
+  },
+  "selectedText": {
+    "description": "Label for selected text reference block",
+    "message": "选中文本"
+  },
+  "selectHighlightColor": {
+    "description": "Label for the highlight color picker dialog.",
+    "message": "选择划线颜色"
+  },
+  "selectModel": {
+    "description": "Agent UI 中模型选择器的标签",
+    "message": "选择模型"
+  },
+  "settings": {
+    "description": "设置按钮/面板的标签",
+    "message": "设置"
+  },
+  "share": {
+    "description": "Label for the share button in selection toolbar.",
+    "message": "分享"
+  },
+  "standard": {
+    "description": "Standard width option.",
+    "message": "标准"
+  },
+  "startConversation": {
+    "description": "无消息时显示的文本",
+    "message": "开始新对话"
+  },
+  "summarize": {
+    "description": "AI 面板中总结文章的操作标签",
+    "message": "总结文章"
+  },
+  "system": {
+    "description": "系统字体选项",
+    "message": "系统"
+  },
+  "text": {
+    "description": "Label for text color setting.",
+    "message": "文本"
+  },
+  "textAlignment": {
+    "description": "Label for text alignment options.",
+    "message": "文本对齐"
+  },
+  "theme": {
+    "description": "Label for theme button.",
+    "message": "主题"
+  },
+  "thinking": {
+    "description": "AI 思考时显示的标签",
+    "message": "思考中..."
+  },
+  "tight": {
+    "description": "Tight line spacing option.",
+    "message": "紧凑"
+  },
+  "tryAgain": {
+    "description": "Label for try again button.",
+    "message": "重试"
+  },
+  "ui": {
+    "description": "UI 颜色设置的标签",
+    "message": "UI"
+  },
+  "welcomeMessage": {
+    "description": "Agent UI 中显示的初始欢迎消息",
+    "message": "我可以帮助你理解当前屏幕上显示的内容。当你滚动页面时，我的上下文会更新以关注你正在阅读的内容。"
+  },
+  "wide": {
+    "description": "Wide width option.",
+    "message": "宽"
+  },
+  "quickSummary": {
+    "description": "Label for the quick summary button/feature.",
+    "message": "快速摘要"
+  },
+  "generatingSummary": {
+    "description": "Text shown when generating a summary.",
+    "message": "正在生成摘要..."
+  },
+  "noSummaryAvailable": {
+    "description": "Text shown when no summary is available.",
+    "message": "暂无可用摘要。"
+  },
+  "translating": {
+    "description": "Label shown when text is being translated.",
+    "message": "翻译中"
+  },
+  "translation": {
+    "description": "Label shown before translated text.",
+    "message": "翻译"
+  },
+  "translate": {
+    "description": "Label for the translate button in selection toolbar.",
+    "message": "翻译"
+  },
+  "translateArticle": {
+    "description": "Label for the translate article button in the toolbar.",
+    "message": "翻译全文"
+  },
+  "translatingArticle": {
+    "description": "Label shown when the article is being translated.",
+    "message": "正在翻译全文"
+  },
+  "translationError": {
+    "description": "Error message shown when translation fails.",
+    "message": "错误"
+  },
+  "translationFailed": {
+    "description": "Detailed error message shown when translation fails.",
+    "message": "翻译失败，请重试"
   }
 }

--- a/src/components/agent/MessageBubble.tsx
+++ b/src/components/agent/MessageBubble.tsx
@@ -1,11 +1,19 @@
-import React, { useState, useEffect } from 'react';
-import { Message, ContextType, ConfirmationData } from './types';
-import { useTheme } from '../../context/ThemeContext';
-import { ChevronDownIcon, ChevronUpIcon, ExclamationCircleIcon, CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
-import { createLogger } from '../../utils/logger';
+import React, { useState, useEffect } from "react";
+import { Message, ContextType, ConfirmationData } from "./types";
+import { useTheme } from "../../context/ThemeContext";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  ClipboardIcon,
+  CheckIcon,
+} from "@heroicons/react/24/outline";
+import { createLogger } from "../../utils/logger";
 
 // Create a logger for MessageBubble
-const logger = createLogger('message-bubble');
+const logger = createLogger("message-bubble");
 
 interface MessageBubbleProps {
   message: Message;
@@ -16,7 +24,16 @@ interface MessageBubbleProps {
 
 // Import or create QuoteIcon if not available
 const QuoteIcon = ({ className }: { className?: string }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" className={className}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
     <path d="M7.5 7h3.75m-3.75 3h3.75m3-6H18m-3.75 3H18m-3.75 3H18M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
   </svg>
 );
@@ -25,31 +42,36 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   message,
   t,
   getContextTypeLabel,
-  renderMarkdown
+  renderMarkdown,
 }) => {
-  const isUser = message.sender === 'user';
+  const isUser = message.sender === "user";
   const [isReferenceExpanded, setIsReferenceExpanded] = useState(true);
   const [isResponded, setIsResponded] = useState(false);
-  
+  const [copied, setCopied] = useState(false);
+
   // Log when system messages with confirmationData are rendered
   useEffect(() => {
-    if (message.sender === 'system' && message.confirmationData) {
-      logger.info(`Rendering system message with confirmation buttons: ${message.id}`);
-      logger.info(`Confirmation data: ${JSON.stringify({
-        type: message.confirmationData.type,
-        tokens: message.confirmationData.estimatedTokens,
-        chunks: message.confirmationData.estimatedChunks,
-        hasApproveCallback: !!message.confirmationData.onApprove,
-        hasCancelCallback: !!message.confirmationData.onCancel
-      })}`);
+    if (message.sender === "system" && message.confirmationData) {
+      logger.info(
+        `Rendering system message with confirmation buttons: ${message.id}`,
+      );
+      logger.info(
+        `Confirmation data: ${JSON.stringify({
+          type: message.confirmationData.type,
+          tokens: message.confirmationData.estimatedTokens,
+          chunks: message.confirmationData.estimatedChunks,
+          hasApproveCallback: !!message.confirmationData.onApprove,
+          hasCancelCallback: !!message.confirmationData.onCancel,
+        })}`,
+      );
     }
   }, [message]);
-  
+
   // Toggle reference visibility
   const toggleReference = () => {
     setIsReferenceExpanded(!isReferenceExpanded);
   };
-  
+
   // Handle confirmation approval
   const handleApprove = () => {
     if (message.confirmationData?.onApprove && !isResponded) {
@@ -58,7 +80,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
       setIsResponded(true);
     }
   };
-  
+
   // Handle confirmation cancellation
   const handleCancel = () => {
     if (message.confirmationData?.onCancel && !isResponded) {
@@ -67,116 +89,162 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
       setIsResponded(true);
     }
   };
-  
+
+  // Handle copy to clipboard
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      logger.error("Failed to copy message", err);
+    }
+  };
+
   // Common prose and text styling classes
-  const markdownClasses = "readlite-agent-markdown-content prose prose-xs max-w-none text-text-primary " +
+  const markdownClasses =
+    "readlite-agent-markdown-content prose prose-xs max-w-none text-text-primary " +
     "prose-headings:text-text-primary prose-pre:bg-bg-primary/10 prose-pre:p-2 " +
     "prose-pre:rounded-md prose-pre:text-xs prose-code:text-xs prose-code:bg-bg-primary/10 " +
     "prose-code:px-1 prose-code:py-0.5 prose-code:rounded-sm prose-a:text-accent " +
     "prose-a:no-underline hover:prose-a:underline text-base leading-relaxed " +
     "font-[system-ui,-apple-system,BlinkMacSystemFont,'Segoe_UI','PingFang_SC','Hiragino_Sans_GB','Microsoft_YaHei',sans-serif] antialiased";
-  
+
   // Should show reference block
-  const shouldShowReference = 
-    !isUser && 
-    message.contextType === 'selection' && 
-    message.reference && 
+  const shouldShowReference =
+    !isUser &&
+    message.contextType === "selection" &&
+    message.reference &&
     message.reference.trim().length > 0;
-  
+
   return (
-    <div className={`flex py-1.5 ${isUser ? 'justify-end px-2.5' : 'justify-start pl-0 pr-4'}`}>
-      <div className={`flex flex-col ${isUser ? 'items-end max-w-[85%]' : 'items-start max-w-[92%]'}`}>
+    <div
+      className={`flex py-1.5 ${isUser ? "justify-end px-2.5" : "justify-start pl-0 pr-4"}`}
+    >
+      <div
+        className={`flex flex-col ${isUser ? "items-end max-w-[85%]" : "items-start max-w-[92%]"}`}
+      >
         {/* System message with confirmation buttons */}
-        {message.sender === 'system' && message.confirmationData ? (
-          <div className="readlite-agent-message-content shadow-sm rounded-md p-4 
-                         bg-bg-primary border-l-4 border-accent text-text-primary">
+        {message.sender === "system" && message.confirmationData ? (
+          <div
+            className="readlite-agent-message-content shadow-sm rounded-md p-4 
+                         bg-bg-primary border-l-4 border-accent text-text-primary"
+          >
             <div className="flex items-center text-accent font-medium mb-3">
               <ExclamationCircleIcon className="w-5 h-5 mr-1.5 flex-shrink-0" />
-              <span className="text-lg">{t('confirmationNeeded') || 'Confirmation Needed'}</span>
+              <span className="text-lg">
+                {t("confirmationNeeded") || "Confirmation Needed"}
+              </span>
             </div>
-            
-            <div 
+
+            <div
               className={markdownClasses}
               dangerouslySetInnerHTML={renderMarkdown(message.text)}
             />
-            
-            {message.confirmationData.type === 'article_size' && (
+
+            {message.confirmationData.type === "article_size" && (
               <div className="mt-3 mb-4 p-2 bg-bg-secondary/30 rounded text-text-secondary text-sm">
                 <div>
-                  <span className="font-medium">Estimated size:</span> {message.confirmationData.estimatedTokens?.toLocaleString() || '?'} tokens
+                  <span className="font-medium">Estimated size:</span>{" "}
+                  {message.confirmationData.estimatedTokens?.toLocaleString() ||
+                    "?"}{" "}
+                  tokens
                 </div>
                 <div>
-                  <span className="font-medium">Will be processed in:</span> {message.confirmationData.estimatedChunks || '?'} chunks
+                  <span className="font-medium">Will be processed in:</span>{" "}
+                  {message.confirmationData.estimatedChunks || "?"} chunks
                 </div>
               </div>
             )}
-            
+
             {!isResponded ? (
               <div className="flex space-x-3 mt-4">
-                <button 
+                <button
                   onClick={handleApprove}
                   className="flex items-center px-4 py-2 bg-accent text-white rounded-md hover:bg-accent/90 transition-colors"
                 >
                   <CheckCircleIcon className="w-5 h-5 mr-1.5" />
-                  <span>{t('approve') || 'Approve'}</span>
+                  <span>{t("approve") || "Approve"}</span>
                 </button>
-                <button 
+                <button
                   onClick={handleCancel}
                   className="flex items-center px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300 transition-colors"
                 >
                   <XCircleIcon className="w-5 h-5 mr-1.5" />
-                  <span>{t('cancel') || 'Cancel'}</span>
+                  <span>{t("cancel") || "Cancel"}</span>
                 </button>
               </div>
             ) : (
               <div className="text-sm italic text-text-secondary mt-3">
-                {t('responseProcessing') || 'Your response is being processed...'}
+                {t("responseProcessing") ||
+                  "Your response is being processed..."}
               </div>
             )}
           </div>
         ) : /* Special styling for old confirmation requests - keep for backwards compatibility */
         !isUser && message.isConfirmationRequest ? (
-          <div className="readlite-agent-message-content shadow-sm rounded-[16px_16px_16px_4px] p-[10px_14px] 
-                         bg-bg-primary border-2 border-accent/50 text-text-primary">
+          <div
+            className="readlite-agent-message-content shadow-sm rounded-[16px_16px_16px_4px] p-[10px_14px] 
+                         bg-bg-primary border-2 border-accent/50 text-text-primary"
+          >
             <div className="flex items-center text-accent font-medium mb-2">
               <ExclamationCircleIcon className="w-4 h-4 mr-1.5" />
-              <span>{t('confirmationNeeded') || 'Confirmation Needed'}</span>
+              <span>{t("confirmationNeeded") || "Confirmation Needed"}</span>
             </div>
-            
-            <div 
+
+            <div
               className={markdownClasses}
               dangerouslySetInnerHTML={renderMarkdown(message.text)}
             />
-            
+
             <div className="mt-3 text-sm text-text-secondary">
-              {t('replyWithYesOrNo') || 'Reply with "yes" to proceed or "no" to cancel.'}
+              {t("replyWithYesOrNo") ||
+                'Reply with "yes" to proceed or "no" to cancel.'}
             </div>
           </div>
         ) : !isUser && message.contextType ? (
           // Normal assistant message with context
-          <div className={`readlite-agent-message-content shadow-sm rounded-[16px_16px_16px_4px] p-[10px_14px] 
-                           bg-bg-agent text-text-agent border border-border`}>
+          <div
+            className={`readlite-agent-message-content shadow-sm rounded-[16px_16px_16px_4px] p-[10px_14px]
+                           bg-bg-agent text-text-agent border border-border relative group`}
+          >
+            {/* Copy button */}
+            <button
+              onClick={handleCopy}
+              className="absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity text-text-secondary hover:text-accent"
+              title={copied ? t("copied") || "Copied" : t("copy") || "Copy"}
+            >
+              {copied ? (
+                <CheckIcon className="w-4 h-4" />
+              ) : (
+                <ClipboardIcon className="w-4 h-4" />
+              )}
+            </button>
+
             {/* Context badge integrated with message */}
             <div className="text-xs text-text-secondary flex items-center mb-1">
               <span>@</span>
-              <span className="ml-0.5">{getContextTypeLabel(message.contextType)}</span>
+              <span className="ml-0.5">
+                {getContextTypeLabel(message.contextType)}
+              </span>
             </div>
-            
+
             {/* Reference block for selections */}
             {shouldShowReference && (
               <div className="mb-2">
-                <div 
+                <div
                   className="flex items-center text-xs text-text-secondary mb-1 cursor-pointer hover:text-accent"
                   onClick={toggleReference}
                 >
                   <QuoteIcon className="w-3.5 h-3.5 mr-1" />
-                  <span>{t('selectedText') || 'Selected Text'}</span>
-                  {isReferenceExpanded ? 
-                    <ChevronUpIcon className="w-3.5 h-3.5 ml-1" /> : 
+                  <span>{t("selectedText") || "Selected Text"}</span>
+                  {isReferenceExpanded ? (
+                    <ChevronUpIcon className="w-3.5 h-3.5 ml-1" />
+                  ) : (
                     <ChevronDownIcon className="w-3.5 h-3.5 ml-1" />
-                  }
+                  )}
                 </div>
-                
+
                 {isReferenceExpanded && (
                   <div className="pl-2 border-l-2 border-accent/30 py-1 pr-2 text-sm bg-bg-primary/5 rounded-r-md italic text-text-secondary/50 my-1">
                     {message.reference}
@@ -184,25 +252,42 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
                 )}
               </div>
             )}
-            
-            <div 
+
+            <div
               className={markdownClasses}
               dangerouslySetInnerHTML={renderMarkdown(message.text)}
             />
           </div>
         ) : !isUser ? (
           // Regular assistant message without context
-          <div className="readlite-agent-message-content shadow-sm rounded-[16px_16px_16px_4px] p-[10px_14px] 
-                          bg-bg-agent text-text-agent border border-border">
-            <div 
+          <div
+            className="readlite-agent-message-content shadow-sm rounded-[16px_16px_16px_4px] p-[10px_14px]
+                          bg-bg-agent text-text-agent border border-border relative group"
+          >
+            {/* Copy button */}
+            <button
+              onClick={handleCopy}
+              className="absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity text-text-secondary hover:text-accent"
+              title={copied ? t("copied") || "Copied" : t("copy") || "Copy"}
+            >
+              {copied ? (
+                <CheckIcon className="w-4 h-4" />
+              ) : (
+                <ClipboardIcon className="w-4 h-4" />
+              )}
+            </button>
+
+            <div
               className={markdownClasses}
               dangerouslySetInnerHTML={renderMarkdown(message.text)}
             />
           </div>
         ) : (
           // User message
-          <div className={`readlite-agent-message-content shadow-sm rounded-[16px_16px_4px_16px] p-[10px_14px] 
-                           bg-bg-user text-text-user ${markdownClasses}`}>
+          <div
+            className={`readlite-agent-message-content shadow-sm rounded-[16px_16px_4px_16px] p-[10px_14px] 
+                           bg-bg-user text-text-user ${markdownClasses}`}
+          >
             {message.text}
           </div>
         )}
@@ -211,4 +296,4 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   );
 };
 
-export default MessageBubble; 
+export default MessageBubble;


### PR DESCRIPTION
## Summary
- add copy-to-clipboard control on assistant messages for quicker reuse
- hint at command shortcuts in agent input placeholder

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689eef68afb08327837aa385296aa277